### PR TITLE
adding optional prependLinksHttps prop to auto prepend links with https://

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@
       v-model="content"
       use-custom-image-handler
       use-markdown-shortcuts
+      prepend-links-https
       @focus="onEditorFocus"
       @blur="onEditorBlur"
       @imageAdded="handleImageAdded"

--- a/src/components/VueEditor.vue
+++ b/src/components/VueEditor.vue
@@ -20,6 +20,7 @@ import defaultToolbar from '@/helpers/default-toolbar';
 import oldApi from '@/helpers/old-api';
 import mergeDeep from '@/helpers/merge-deep';
 import MarkdownShortcuts from '@/helpers/markdown-shortcuts';
+import CustomLink from '@/helpers/custom-link';
 
 export default {
   name: 'VueEditor',
@@ -69,6 +70,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    prependLinksHttps: {
+      type: Boolean,
+      default: false
+    }
   },
 
   data: () => ({
@@ -126,6 +131,9 @@ export default {
       if (this.useMarkdownShortcuts) {
         Quill.register('modules/markdownShortcuts', MarkdownShortcuts, true);
         modules['markdownShortcuts'] = {};
+      }
+      if (this.prependLinksHttps) {
+        Quill.register('formats/link', CustomLink, true);
       }
       return modules;
     },

--- a/src/helpers/custom-link.js
+++ b/src/helpers/custom-link.js
@@ -9,7 +9,7 @@ export default class CustomLink extends Link {
         if (value.startsWith(this.PROTOCOL_WHITELIST[i])) {
           return value;
         }
-        return `https://${value}`
+        return `https://${value}`;
     }
     return value;
   }

--- a/src/helpers/custom-link.js
+++ b/src/helpers/custom-link.js
@@ -1,0 +1,16 @@
+import Quill from 'quill';
+const Link = Quill.import('formats/link');
+
+export default class CustomLink extends Link {
+  static sanitize(url) {
+    const value = super.sanitize(url);
+    if (value) {
+      for (let i = 0; i < this.PROTOCOL_WHITELIST.length; i++)
+        if (value.startsWith(this.PROTOCOL_WHITELIST[i])) {
+          return value;
+        }
+        return `https://${value}`
+    }
+    return value;
+  }
+}


### PR DESCRIPTION
Adding a prop (defaults to false) that will prepend added link URL's with https://

This checks for existing https, tel, or mailto at the start of the URL and will not prepend with https:// if present.

Can use my fork for this, so feel free to close this, just thought it may be useful.